### PR TITLE
Limits the depth of complex types to 2.

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -69,7 +69,10 @@
    *   "levelTwoKey4": {
    *     "levelThreeKey1": "value3",
    *     "levelThreeKey2": 3,
-   *     "levelThreeKey3": [7, 8, 9]
+   *     "levelThreeKey3": [7, 8, 9],
+   *     "levelThreeKey4": {
+   *       "levelFourKey1": 4
+   *     }
    *   }
    *  }
    * }
@@ -81,7 +84,11 @@
    * "levelOneKey4": {
    *   "levelTwoKey1": "value2",
    *   "levelTwoKey2": 2,
-   *   "levelTwoKey3": [4, 5, 6]
+   *   "levelTwoKey3": [4, 5, 6],
+   *   "levelTwoKey4": {
+   *     "levelThreeKey1": "value3",
+   *     "levelThreeKey2": 3,
+   *     "levelThreeKey3": [7, 8, 9]
    *  }
    * }
    ###
@@ -98,7 +105,11 @@
         for levelTwoKey in levelTwoKeys
           levelTwoValue = levelOneValue[levelTwoKey];
           if isObject(levelTwoValue)
-            delete levelOneValue[levelTwoKey]
+            levelThreeKeys = Object.keys(levelTwoValue);
+            for levelThreeKey in levelThreeKeys
+              levelThreeValue = levelTwoValue[levelThreeKey];
+              if isObject(levelThreeValue)
+                delete levelTwoValue[levelThreeKey]
 
   str = (obj, attached) ->
     clonedObj = Object.assign({}, obj)

--- a/index.coffee
+++ b/index.coffee
@@ -50,26 +50,23 @@
   limitDepth = (object, maxDepth, currentDepth) ->
     if (!(object instanceof Object))
       return;
-    if currentDepth == undefined
-      currentDepth = 1;
-    if Array.isArray(object)
-      for child in object
-        limitDepth(child, maxDepth, currentDepth + 1)
-    else
-      keys = Object.keys(object);
-      for key in keys
-        child = object[key];
-        if child instanceof Object
-          if !Array.isArray(child) && currentDepth > maxDepth
-            delete object[key];
-          else
-            limitDepth(child, maxDepth, currentDepth + 1)
+    if object instanceof Array
+      return;
+    firstDepthKeys = Object.keys(object);
+    for firstDepthKey in firstDepthKeys
+      firstDepthChild = object[firstDepthKey];
+      if firstDepthChild instanceof Object && !(firstDepthChild instanceof Array)
+        secondDepthKeys = Object.keys(firstDepthChild);
+        for secondDepthKey in secondDepthKeys
+          secondDepthChild = firstDepthChild[secondDepthKey];
+          if secondDepthChild instanceof Object && !(secondDepthChild instanceof Array)
+            delete firstDepthChild[secondDepthKey]
   str = (obj, attached) ->
-    MAX_DEPTH = 2
-    limitDepth(obj, MAX_DEPTH)
+    clonedObj = Object.assign({}, obj)
+    limitDepth(clonedObj)
     array = undefined
     root = true
-    JSON.stringify obj, (k,v) ->
+    JSON.stringify clonedObj, (k,v) ->
       if not root
         if attached and (attached.length == 0 or k in attached) or array
           if not (v instanceof Array)

--- a/index.coffee
+++ b/index.coffee
@@ -47,39 +47,6 @@
       promise(d)
   selfLink = (obj) -> obj?.$bind?.self
   clean = (url) -> String(url).replace /{.*}/g, '' if url
-
-  ###*
-   * Limits the depth of complex types to 2.
-   * Note: We intentionally avoid recursion here. 
-   * This here
-   * {
-   * "object": {
-   *   "levelOneKey1": "value2",
-   *   "levelOneKey2": 2,
-   *   "levelOneKey3": [4, 5, 6],
-   *   "levelOneKey4": {
-   *     "levelTwoKey1": "value3",
-   *     "levelTwoKey2": 3,
-   *     "levelTwoKey3": [7, 8, 9],
-   *     "levelTwoKey4": {
-   *       "levelThreeKey1": 4
-   *     }
-   *   }
-   *  }
-   * }
-   * becomes
-   * {
-   * "object": {
-   *   "levelOneKey1": "value2",
-   *   "levelOneKey2": 2,
-   *   "levelOneKey3": [4, 5, 6],
-   *   "levelOneKey4": {
-   *     "levelTwoKey1": "value3",
-   *     "levelTwoKey2": 3,
-   *     "levelTwoKey3": [7, 8, 9]
-   *  }
-   * }
-   ###
   stringify = (val, depth, replacer, space) ->
     _build = (key, val, depth, o, a) ->
       if !val or typeof val != 'object'
@@ -101,7 +68,6 @@
             return
         o or if !key then {} else undefined
     JSON.stringify _build('', val, depth), null, space
-  
   str = (obj, attached) ->
     array = undefined
     root = true

--- a/index.coffee
+++ b/index.coffee
@@ -52,14 +52,18 @@
       return;
     if currentDepth == undefined
       currentDepth = 1;
-    keys = Object.keys(object);
-    for key in keys
-      child = object[key];
-      if child instanceof Object
-        if currentDepth > maxDepth
-          delete object[key];
-        else
-          limitDepth(child, maxDepth, currentDepth + 1)
+    if Array.isArray(object)
+      for child in object
+        limitDepth(child, maxDepth, currentDepth + 1)
+    else
+      keys = Object.keys(object);
+      for key in keys
+        child = object[key];
+        if child instanceof Object
+          if !Array.isArray(child) && currentDepth > maxDepth
+            delete object[key];
+          else
+            limitDepth(child, maxDepth, currentDepth + 1)
   str = (obj, attached) ->
     MAX_DEPTH = 2
     limitDepth(obj, MAX_DEPTH)

--- a/index.coffee
+++ b/index.coffee
@@ -147,7 +147,7 @@
       , d.reject
       promise d
     defProp = (obj, name, value) ->
-      Object.defineProperty obj, name, configurable: true, enumerable: false, value: value
+      Object.defineProperty obj, name, configurable: true, enumerable: false, writable: true, value: value
     postEnrich = (obj) -> obj;
     enrich = (obj, url) ->
       if not obj.$bind

--- a/index.coffee
+++ b/index.coffee
@@ -52,7 +52,7 @@
   * Returns true if value is an Object. Note that JavaScript arrays and functions are objects,
   * while (normal) strings and numbers are not.
   ###
-  isObject = (value) value instanceof Object && !(value instanceof Array)
+  isObject = (value) -> value instanceof Object && !(value instanceof Array)
 
   ###*
    * Limits the depth of complex types to 2.

--- a/index.coffee
+++ b/index.coffee
@@ -47,20 +47,59 @@
       promise(d)
   selfLink = (obj) -> obj?.$bind?.self
   clean = (url) -> String(url).replace /{.*}/g, '' if url
+
+  ###*
+  * Returns true if value is an Object. Note that JavaScript arrays and functions are objects,
+  * while (normal) strings and numbers are not.
+  ###
+  isObject = (value) value instanceof Object && !(value instanceof Array)
+
+  ###*
+   * Limits the depth of complex types to 2.
+   * Note: We intentionally avoid recursion here. 
+   * This here
+   * {
+   * "levelOneKey1": "value1",
+   * "levelOneKey2": 1,
+   * "levelOneKey3": [1, 2, 3],
+   * "levelOneKey4": {
+   *   "levelTwoKey1": "value2",
+   *   "levelTwoKey2": 2,
+   *   "levelTwoKey3": [4, 5, 6],
+   *   "levelTwoKey4": {
+   *     "levelThreeKey1": "value3",
+   *     "levelThreeKey2": 3,
+   *     "levelThreeKey3": [7, 8, 9]
+   *   }
+   *  }
+   * }
+   * becomes
+   * {
+   * "levelOneKey1": "value1",
+   * "levelOneKey2": 1,
+   * "levelOneKey3": [1, 2, 3],
+   * "levelOneKey4": {
+   *   "levelTwoKey1": "value2",
+   *   "levelTwoKey2": 2,
+   *   "levelTwoKey3": [4, 5, 6]
+   *  }
+   * }
+   ###
   limitDepth = (object) ->
     if (!(object instanceof Object))
       return;
     if object instanceof Array
       return;
-    firstDepthKeys = Object.keys(object);
-    for firstDepthKey in firstDepthKeys
-      firstDepthChild = object[firstDepthKey];
-      if firstDepthChild instanceof Object && !(firstDepthChild instanceof Array)
-        secondDepthKeys = Object.keys(firstDepthChild);
-        for secondDepthKey in secondDepthKeys
-          secondDepthChild = firstDepthChild[secondDepthKey];
-          if secondDepthChild instanceof Object && !(secondDepthChild instanceof Array)
-            delete firstDepthChild[secondDepthKey]
+    levelOneKeys = Object.keys(object);
+    for levelOneKey in levelOneKeys
+      levelOneValue = object[levelOneKey];
+      if isObject(levelOneValue)
+        levelTwoKeys = Object.keys(levelOneValue);
+        for levelTwoKey in levelTwoKeys
+          levelTwoValue = levelOneValue[levelTwoKey];
+          if isObject(levelTwoValue)
+            delete levelOneValue[levelTwoKey]
+
   str = (obj, attached) ->
     clonedObj = Object.assign({}, obj)
     limitDepth(clonedObj)

--- a/index.coffee
+++ b/index.coffee
@@ -47,7 +47,7 @@
       promise(d)
   selfLink = (obj) -> obj?.$bind?.self
   clean = (url) -> String(url).replace /{.*}/g, '' if url
-  limitDeepObjectProperties = (object, maxDepth, currentDepth) ->
+  limitDepth = (object, maxDepth, currentDepth) ->
     if (!(object instanceof Object))
       return;
     if currentDepth == undefined
@@ -59,9 +59,10 @@
         if currentDepth > maxDepth
           delete object[key];
         else
-          limitDeepObjectProperties(child, maxDepth, currentDepth + 1)
+          limitDepth(child, maxDepth, currentDepth + 1)
   str = (obj, attached) ->
-    limitDeepObjectProperties(obj, 2)
+    MAX_DEPTH = 2
+    limitDepth(obj, MAX_DEPTH)
     array = undefined
     root = true
     JSON.stringify obj, (k,v) ->
@@ -97,7 +98,6 @@
               bind item[name]
           else
             item.$bind.self = clean link.href
-        delete item._links
       if item instanceof Array
         for i in item
           link = i?._links?.self?.href
@@ -266,8 +266,12 @@
       postEnrich(obj)
     root =
       $id: (fn) -> idFn = fn
-      $postEnrich: (pe) -> postEnrich = pe
-      $postCollMap: (pcm) -> postCollMap = pcm
+      $postEnrich: (pe) ->
+        postEnrich = pe
+        return
+      $postCollMap: (pcm) ->
+        postCollMap = pcm
+        return
     enrich root, url
   hybind.http = http
   hybind

--- a/index.coffee
+++ b/index.coffee
@@ -112,11 +112,11 @@
                 delete levelTwoValue[levelThreeKey]
 
   str = (obj, attached) ->
-    clonedObj = Object.assign({}, obj)
-    limitDepth(clonedObj)
     array = undefined
     root = true
-    JSON.stringify clonedObj, (k,v) ->
+    JSON.stringify obj, (k,v) ->
+      if k == ''
+        limitDepth(v)
       if not root
         if attached and (attached.length == 0 or k in attached) or array
           if not (v instanceof Array)

--- a/index.coffee
+++ b/index.coffee
@@ -150,7 +150,7 @@
       , d.reject
       promise d
     defProp = (obj, name, value) ->
-      Object.defineProperty obj, name, configurable: true, enumerable: false, writable: true, value: value
+      Object.defineProperty obj, name, configurable: true, enumerable: false, value: value
     enrich = (obj, url) ->
       if not obj.$bind
          defProp obj, '$bind', ->

--- a/index.coffee
+++ b/index.coffee
@@ -47,7 +47,7 @@
       promise(d)
   selfLink = (obj) -> obj?.$bind?.self
   clean = (url) -> String(url).replace /{.*}/g, '' if url
-  limitDepth = (object, maxDepth, currentDepth) ->
+  limitDepth = (object) ->
     if (!(object instanceof Object))
       return;
     if object instanceof Array

--- a/index.coffee
+++ b/index.coffee
@@ -155,7 +155,6 @@
           if link
             enrich i, link
             bind i
-    postCollMap = (obj) -> obj;
     collMapper = (obj, coll) ->
       coll.length = 0
       if obj._embedded
@@ -166,7 +165,6 @@
             if link
               enrich item, link
               item.$bind.ref = coll?.$bind?.self+'/'+link.split('/')[-1..]
-              postCollMap(coll, item);
             bind item
           break
         delete obj.embedded
@@ -198,7 +196,6 @@
       promise d
     defProp = (obj, name, value) ->
       Object.defineProperty obj, name, configurable: true, enumerable: false, writable: true, value: value
-    postEnrich = (obj) -> obj;
     enrich = (obj, url) ->
       if not obj.$bind
          defProp obj, '$bind', ->
@@ -314,11 +311,8 @@
         cache[link] = item if not cached
         if cb and not cached then cb item
         item
-      postEnrich(obj)
-    root =
-      $id: (fn) -> idFn = fn
-      $postEnrich: (pe) -> postEnrich = pe
-      $postCollMap: (pcm) -> postCollMap = pcm
+      obj
+    root = $id: (fn) -> idFn = fn
     enrich root, url
   hybind.http = http
   hybind

--- a/index.coffee
+++ b/index.coffee
@@ -306,12 +306,8 @@
       postEnrich(obj)
     root =
       $id: (fn) -> idFn = fn
-      $postEnrich: (pe) ->
-        postEnrich = pe
-        return
-      $postCollMap: (pcm) ->
-        postCollMap = pcm
-        return
+      $postEnrich: (pe) -> postEnrich = pe
+      $postCollMap: (pcm) -> postCollMap = pcm
     enrich root, url
   hybind.http = http
   hybind

--- a/index.spec.coffee
+++ b/index.spec.coffee
@@ -182,11 +182,11 @@ describe 'hybind', ->
             data: JSON.stringify name: 'john'
           done()
 
-      it 'should issue a PUT request by drop the fields on depth level 2 that are object', (done) ->
+      it 'should drop properties of type object on depth level 2 and deeper', (done) ->
         http = @http
         john = @john
         john.address = city: name: 'Abanda', toName: 'Oliver', geoPoint: latitude: 1, longitude: 2
-        @john.$save().then (obj) ->
+        john.$save().then (obj) ->
           expect(obj).toBe john
           expect(http).toHaveBeenCalledWith jasmine.objectContaining
             method: 'PUT', url: 'http://localhost/john'

--- a/index.spec.coffee
+++ b/index.spec.coffee
@@ -182,6 +182,17 @@ describe 'hybind', ->
             data: JSON.stringify name: 'john'
           done()
 
+      it 'should issue a PUT request by drop the fields on depth level 2 that are object', (done) ->
+        http = @http
+        john = @john
+        john.address = city: name: 'Abanda', toName: 'Oliver', geoPoint: latitude: 1, longitude: 2
+        @john.$save().then (obj) ->
+          expect(obj).toBe john
+          expect(http).toHaveBeenCalledWith jasmine.objectContaining
+            method: 'PUT', url: 'http://localhost/john'
+            data: JSON.stringify name: 'john', address: city: name: 'Abanda', toName: 'Oliver'
+          done()
+
       it 'should support parameters', (done) ->
         http = @http
         @john.$save(p: true).then ->

--- a/index.spec.coffee
+++ b/index.spec.coffee
@@ -191,18 +191,20 @@ describe 'hybind', ->
           expect(http).toHaveBeenCalledWith jasmine.objectContaining
             method: 'PUT', url: 'http://localhost/john'
             data: JSON.stringify name: 'john', address: city: name: 'Abanda', toName: 'Oliver'
-          done()
+        expect(JSON.stringify john).toBe JSON.stringify name : 'john', address : city: name: 'Abanda', toName: 'Oliver', geoPoint: latitude: 1, longitude: 2
+        done()
 
       it 'should not drop properties of type Array on depth level 2 and deeper', (done) ->
         http = @http
         john = @john
-        john.address = city: name: 'Abanda', toName: 'Oliver', frequencies: [value: 427, unit: 'MHZ']
+        john.address = city: name: 'Abanda', toName: 'Oliver', frequencies: [{value: 427, unit: 'MHZ'}, {value: 428, unit: 'MHZ'}]
         john.$save().then (obj) ->
           expect(obj).toBe john
           expect(http).toHaveBeenCalledWith jasmine.objectContaining
             method: 'PUT', url: 'http://localhost/john'
-            data: JSON.stringify name: 'john', address: city: name: 'Abanda', toName: 'Oliver', frequencies: [value: 427, unit: 'MHZ']
-          done()
+            data: JSON.stringify name: 'john', address: city: name: 'Abanda', toName: 'Oliver', frequencies: [{value: 427, unit: 'MHZ'}, {value: 428, unit: 'MHZ'}]
+        expect(JSON.stringify john).toBe JSON.stringify name : 'john', address : city: name: 'Abanda', toName: 'Oliver', frequencies: [{value: 427, unit: 'MHZ'}, {value: 428, unit: 'MHZ'}]
+        done()
 
       it 'should support parameters', (done) ->
         http = @http

--- a/index.spec.coffee
+++ b/index.spec.coffee
@@ -191,8 +191,8 @@ describe 'hybind', ->
           expect(http).toHaveBeenCalledWith jasmine.objectContaining
             method: 'PUT', url: 'http://localhost/john'
             data: JSON.stringify name: 'john', address: city: name: 'Abanda', toName: 'Oliver'
-        expect(JSON.stringify john).toBe JSON.stringify name : 'john', address : city: name: 'Abanda', toName: 'Oliver', geoPoint: latitude: 1, longitude: 2
-        done()
+          expect(JSON.stringify john).toBe JSON.stringify name : 'john', address : city: name: 'Abanda', toName: 'Oliver', geoPoint: latitude: 1, longitude: 2
+          done()
 
       it 'should not drop properties of type Array on depth level 2 and deeper', (done) ->
         http = @http
@@ -203,8 +203,8 @@ describe 'hybind', ->
           expect(http).toHaveBeenCalledWith jasmine.objectContaining
             method: 'PUT', url: 'http://localhost/john'
             data: JSON.stringify name: 'john', address: city: name: 'Abanda', toName: 'Oliver', frequencies: [{value: 427, unit: 'MHZ'}, {value: 428, unit: 'MHZ'}]
-        expect(JSON.stringify john).toBe JSON.stringify name : 'john', address : city: name: 'Abanda', toName: 'Oliver', frequencies: [{value: 427, unit: 'MHZ'}, {value: 428, unit: 'MHZ'}]
-        done()
+          expect(JSON.stringify john).toBe JSON.stringify name : 'john', address : city: name: 'Abanda', toName: 'Oliver', frequencies: [{value: 427, unit: 'MHZ'}, {value: 428, unit: 'MHZ'}]
+          done()
 
       it 'should support parameters', (done) ->
         http = @http

--- a/index.spec.coffee
+++ b/index.spec.coffee
@@ -450,14 +450,3 @@ describe 'hybind', ->
             method: 'PUT', url: 'http://localhost/addresses'
             data: "http://localhost/addresses/london\nhttp://localhost/addresses/paris"
           done()
-
-    describe '$postEnrich', ->
-      it 'should set a handler to the postEnrich field', (done) ->
-        addresses = @addresses
-        hy = @hybind('');
-        handler = (obj) -> {
-#          console.log('handle: ' + obj);
-        };
-        hy.$postEnrich(handler)
-        addresses.$save()
-        done()

--- a/index.spec.coffee
+++ b/index.spec.coffee
@@ -193,6 +193,17 @@ describe 'hybind', ->
             data: JSON.stringify name: 'john', address: city: name: 'Abanda', toName: 'Oliver'
           done()
 
+      it 'should not drop properties of type Array on depth level 2 and deeper', (done) ->
+        http = @http
+        john = @john
+        john.address = city: name: 'Abanda', toName: 'Oliver', frequencies: [value: 427, unit: 'MHZ']
+        john.$save().then (obj) ->
+          expect(obj).toBe john
+          expect(http).toHaveBeenCalledWith jasmine.objectContaining
+            method: 'PUT', url: 'http://localhost/john'
+            data: JSON.stringify name: 'john', address: city: name: 'Abanda', toName: 'Oliver', frequencies: [value: 427, unit: 'MHZ']
+          done()
+
       it 'should support parameters', (done) ->
         http = @http
         @john.$save(p: true).then ->
@@ -439,3 +450,14 @@ describe 'hybind', ->
             method: 'PUT', url: 'http://localhost/addresses'
             data: "http://localhost/addresses/london\nhttp://localhost/addresses/paris"
           done()
+
+    describe '$postEnrich', ->
+      it 'should set a handler to the postEnrich field', (done) ->
+        addresses = @addresses
+        hy = @hybind('');
+        handler = (obj) -> {
+#          console.log('handle: ' + obj);
+        };
+        hy.$postEnrich(handler)
+        addresses.$save()
+        done()

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "devDependencies": {
     "coffee-script": "^1.10.0",
-    "jasmine-node": "^3.0.0"
+    "jasmine-node": "^1.14.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "devDependencies": {
     "coffee-script": "^1.10.0",
-    "jasmine-node": "^1.14.5"
+    "jasmine-node": "^3.0.0"
   }
 }


### PR DESCRIPTION
Limits the depth of complex types to 2.

This here
```
{
  "object": {
    "levelOneKey1": "value2",
    "levelOneKey2": 2,
    "levelOneKey3": [4, 5, 6],
    "levelOneKey4": {
      "levelTwoKey1": "value3",
         "levelTwoKey2": 3,
         "levelTwoKey3": [7, 8, 9],
         "levelTwoKey4": {
           "levelThreeKey1": 4
         }
    }
  }
}
```
becomes
 ```
{
    "object": {
      "levelOneKey1": "value2",
      "levelOneKey2": 2,
      "levelOneKey3": [4, 5, 6],
      "levelOneKey4": {
          "levelTwoKey1": "value3",
          "levelTwoKey2": 3,
         "levelTwoKey3": [7, 8, 9]
        }
    }
}
```

There will be one more (no related to this change) change to add **postEnrich** and **postCollMap** functions.