### PR TITLE
Return a promise that resolves with the model object that corresponds to the payload in the response from the server (if there is one)

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -110,7 +110,7 @@
           if link
             enrich i, link
             bind i
-    postCollMap = (obj) -> obj;
+    postCollMap = (coll, item) -> {};
     collMapper = (obj, coll) ->
       coll.length = 0
       if obj._embedded

--- a/index.coffee
+++ b/index.coffee
@@ -144,6 +144,7 @@
           if link
             enrich i, link
             bind i
+    postCollMap = (obj) -> obj;
     collMapper = (obj, coll) ->
       coll.length = 0
       if obj._embedded
@@ -154,6 +155,7 @@
             if link
               enrich item, link
               item.$bind.ref = coll?.$bind?.self+'/'+link.split('/')[-1..]
+              postCollMap(coll, item);
             bind item
           break
         delete obj.embedded
@@ -185,6 +187,7 @@
       promise d
     defProp = (obj, name, value) ->
       Object.defineProperty obj, name, configurable: true, enumerable: false, writable: true, value: value
+    postEnrich = (obj) -> obj;
     enrich = (obj, url) ->
       if not obj.$bind
          defProp obj, '$bind', ->
@@ -300,8 +303,11 @@
         cache[link] = item if not cached
         if cb and not cached then cb item
         item
-      obj
-    root = $id: (fn) -> idFn = fn
+      postEnrich(obj)
+    root =
+      $id: (fn) -> idFn = fn
+      $postEnrich: (pe) -> postEnrich = pe
+      $postCollMap: (pcm) -> postCollMap = pcm
     enrich root, url
   hybind.http = http
   hybind

--- a/index.coffee
+++ b/index.coffee
@@ -110,7 +110,7 @@
           if link
             enrich i, link
             bind i
-    postCollMap = (coll, item) -> return;
+    onLoadItem = (coll, item) -> return;
     collMapper = (obj, coll) ->
       coll.length = 0
       if obj._embedded
@@ -121,7 +121,7 @@
             if link
               enrich item, link
               item.$bind.ref = coll?.$bind?.self+'/'+link.split('/')[-1..]
-              postCollMap(coll, item);
+              onLoadItem(coll, item);
             bind item
           break
         delete obj.embedded
@@ -153,7 +153,7 @@
       promise d
     defProp = (obj, name, value) ->
       Object.defineProperty obj, name, configurable: true, enumerable: false, writable: true, value: value
-    postEnrich = (obj) -> obj;
+    onBind = (obj) -> return;
     enrich = (obj, url) ->
       if not obj.$bind
          defProp obj, '$bind', ->
@@ -269,11 +269,12 @@
         cache[link] = item if not cached
         if cb and not cached then cb item
         item
-      postEnrich(obj)
+      onBind(obj)
+      obj
     root =
       $id: (fn) -> idFn = fn
-      $postEnrich: (pe) -> postEnrich = pe
-      $postCollMap: (pcm) -> postCollMap = pcm
+      $onBind: (ob) -> onBind = ob
+      $onLoadItem: (oil) -> onLoadItem = oil
     enrich root, url
   hybind.http = http
   hybind

--- a/index.coffee
+++ b/index.coffee
@@ -110,7 +110,7 @@
           if link
             enrich i, link
             bind i
-    postCollMap = (coll, item) -> {};
+    postCollMap = (coll, item) -> return;
     collMapper = (obj, coll) ->
       coll.length = 0
       if obj._embedded

--- a/index.coffee
+++ b/index.coffee
@@ -148,7 +148,7 @@
             data = JSON.parse(data)
         catch e
           d.reject e
-        d.resolve result or data
+        d.resolve data or result
       , d.reject
       promise d
     defProp = (obj, name, value) ->

--- a/index.spec.coffee
+++ b/index.spec.coffee
@@ -97,6 +97,20 @@ describe 'hybind', ->
         postEnrichObj = obj;
       @api.$bind addresses, 'addresses'
       expect(postEnrichObj).toBe(addresses)
+    it 'should handle an item when it is loaded with an array as the first embedded member', (done) ->
+      postEnrichObj = null;
+      item = {};
+      @api.$bind item, 'item'
+      @api.$postEnrich (obj) ->
+        postEnrichObj = obj;
+      @http.andReturn Q
+        _links: self: href: item.$bind.self
+        _embedded:
+          array: []
+        page: number: 0
+      item.$load().then ->
+        expect(postEnrichObj).toBe(item)
+        done()
 
   describe '$postCollMap', ->
     it 'should handle collection items after they are loaded', (done) ->
@@ -118,7 +132,7 @@ describe 'hybind', ->
             city: 'Paris'
           ]
         page: number: 0
-      
+
       addresses.$load().then ->
         expect(postCollMapCall).toBe(addresses)
         expect(postCollMapItem).toBe(addresses[0])

--- a/index.spec.coffee
+++ b/index.spec.coffee
@@ -243,7 +243,9 @@ describe 'hybind', ->
       it 'should issue a PUT request', (done) ->
         http = @http
         john = @john
-        john.errors = [{validationError: 'name too short'}]
+        john.errors = [
+          { validationError: 'name too short' }
+        ]
         response = {
           _links: ''
           _embedded:
@@ -253,6 +255,20 @@ describe 'hybind', ->
         http.andReturn Q response
         john.$save().then (obj) ->
           expect(obj).toBe response
+          expect(http).toHaveBeenCalledWith jasmine.objectContaining
+            method: 'PUT', url: 'http://localhost/john'
+            data: JSON.stringify john
+          done()
+          
+      it 'should issue a PUT request and ignore the response', (done) ->
+        http = @http
+        john = @john
+        john.errors = [
+          { validationError: 'name too short' }
+        ]
+        http.andReturn Q null
+        john.$save().then (obj) ->
+          expect(obj).toBe john
           expect(http).toHaveBeenCalledWith jasmine.objectContaining
             method: 'PUT', url: 'http://localhost/john'
             data: JSON.stringify john

--- a/index.spec.coffee
+++ b/index.spec.coffee
@@ -13,10 +13,10 @@ describe 'hybind', ->
       expect(@api.$bind.self).toBe 'http://localhost'
     it 'should have $bind function', ->
       expect(typeof @api.$bind).toBe 'function'
-    it 'should have $postEnrich function', ->
-      expect(typeof @api.$postEnrich).toBe 'function'
-    it 'should have $postCollMap function', ->
-      expect(typeof @api.$postCollMap).toBe 'function'
+    it 'should have $onBind function', ->
+      expect(typeof @api.$onBind).toBe 'function'
+    it 'should have $onLoadItem function', ->
+      expect(typeof @api.$onLoadItem).toBe 'function'
 
   describe '$bind', ->
     describe 'without object', ->
@@ -86,51 +86,51 @@ describe 'hybind', ->
         @api.$bind 'addresses', addresses
         expect(@api.addresses).toBe addresses
 
-  describe '$postEnrich', ->
+  describe '$onBind', ->
     it 'should set a handler in order to handle collection items after they are bound', ->
-      postEnrichObj = null;
+      onBindObj = null;
       addresses = [
         { _links: self: href: 'http://localhost/london' },
         { _links: self: href: 'http://localhost/paris' }
       ]
-      @api.$postEnrich (obj) ->
-        postEnrichObj = obj;
+      @api.$onBind (obj) ->
+        onBindObj = obj;
       @api.$bind addresses, 'addresses'
-      expect(postEnrichObj).toBe(addresses)
+      expect(onBindObj).toBe(addresses)
     it 'should set a handler in order to handle an item when it is loaded with an array as the first embedded member', (done) ->
-      postEnrichObj = null;
+      onBindObj = null;
       item = {};
       @api.$bind item, 'item'
-      @api.$postEnrich (obj) ->
-        postEnrichObj = obj;
+      @api.$onBind (obj) ->
+        onBindObj = obj;
       @http.andReturn Q
         _links: self: href: item.$bind.self
         _embedded:
           array: []
         page: number: 0
       item.$load().then ->
-        expect(postEnrichObj).toBe(item)
+        expect(onBindObj).toBe(item)
         done()
     it 'should set a handler in order to handle an item after it is created', (done) ->
-      postEnrichObj = null;
+      onBindObj = null;
       item = name: 'item';
       @api.$bind item, 'item'
-      @api.$postEnrich (obj) ->
-        postEnrichObj = obj;
+      @api.$onBind (obj) ->
+        onBindObj = obj;
       @http.andReturn Q
         _links: self: href: 'http://localhost/item'
         name: item.name
       item.$create().then ->
-        expect(JSON.stringify(postEnrichObj)).toBe(JSON.stringify(item))
+        expect(JSON.stringify(onBindObj)).toBe(JSON.stringify(item))
         done()
 
-  describe '$postCollMap', ->
+  describe '$onLoadItem', ->
     it 'should set a handler in order to handle collection items after they are loaded', (done) ->
-      postCollMapCall = null;
-      postCollMapItem = null;
-      @api.$postCollMap (coll, item) ->
-        postCollMapCall = coll
-        postCollMapItem = item
+      onLoadItemCall = null;
+      onLoadItemItem = null;
+      @api.$onLoadItem (coll, item) ->
+        onLoadItemCall = coll
+        onLoadItemItem = item
       
       addresses = {}
       @api.$bind 'addresses', addresses
@@ -146,8 +146,8 @@ describe 'hybind', ->
         page: number: 0
 
       addresses.$load().then ->
-        expect(postCollMapCall).toBe(addresses)
-        expect(postCollMapItem).toBe(addresses[0])
+        expect(onLoadItemCall).toBe(addresses)
+        expect(onLoadItemItem).toBe(addresses[0])
         done()
 
   describe 'operations on objects', ->

--- a/index.spec.coffee
+++ b/index.spec.coffee
@@ -87,7 +87,7 @@ describe 'hybind', ->
         expect(@api.addresses).toBe addresses
 
   describe '$postEnrich', ->
-    it 'should handle collection items after they are bound', ->
+    it 'should set a handler in order to handle collection items after they are bound', ->
       postEnrichObj = null;
       addresses = [
         { _links: self: href: 'http://localhost/london' },
@@ -97,7 +97,7 @@ describe 'hybind', ->
         postEnrichObj = obj;
       @api.$bind addresses, 'addresses'
       expect(postEnrichObj).toBe(addresses)
-    it 'should handle an item when it is loaded with an array as the first embedded member', (done) ->
+    it 'should set a handler in order to handle an item when it is loaded with an array as the first embedded member', (done) ->
       postEnrichObj = null;
       item = {};
       @api.$bind item, 'item'
@@ -111,9 +111,21 @@ describe 'hybind', ->
       item.$load().then ->
         expect(postEnrichObj).toBe(item)
         done()
+    it 'should set a handler in order to handle an item after it is created', (done) ->
+      postEnrichObj = null;
+      item = name: 'item';
+      @api.$bind item, 'item'
+      @api.$postEnrich (obj) ->
+        postEnrichObj = obj;
+      @http.andReturn Q
+        _links: self: href: 'http://localhost/item'
+        name: item.name
+      item.$create().then ->
+        expect(JSON.stringify(postEnrichObj)).toBe(JSON.stringify(item))
+        done()
 
   describe '$postCollMap', ->
-    it 'should handle collection items after they are loaded', (done) ->
+    it 'should set a handler in order to handle collection items after they are loaded', (done) ->
       postCollMapCall = null;
       postCollMapItem = null;
       @api.$postCollMap (coll, item) ->

--- a/index.spec.coffee
+++ b/index.spec.coffee
@@ -243,11 +243,19 @@ describe 'hybind', ->
       it 'should issue a PUT request', (done) ->
         http = @http
         john = @john
-        @john.$save().then (obj) ->
-          expect(obj).toBe john
+        john.errors = [{validationError: 'name too short'}]
+        response = {
+          _links: ''
+          _embedded:
+            name: john.name
+            errors: [] # the validation error is gone
+        }
+        http.andReturn Q response
+        john.$save().then (obj) ->
+          expect(obj).toBe response
           expect(http).toHaveBeenCalledWith jasmine.objectContaining
             method: 'PUT', url: 'http://localhost/john'
-            data: JSON.stringify name: 'john'
+            data: JSON.stringify john
           done()
 
       it 'should drop properties of type object on depth level 2 and deeper', (done) ->
@@ -298,11 +306,12 @@ describe 'hybind', ->
     describe '$delete', ->
       it 'should DELETE the loaded self link', (done) ->
         http = @http
-        http.andReturn Q _links: self: href: 'http://remotehost/john'
+        response = _links: self: href: 'http://remotehost/john'
+        http.andReturn Q response
         john = @john
         john.$load().then ->
           john.$delete().then (obj) ->
-            expect(obj).toBe john
+            expect(obj).toBe response
             expect(http).toHaveBeenCalledWith jasmine.objectContaining
               method: 'DELETE', url: 'http://remotehost/john'
             done()
@@ -367,12 +376,13 @@ describe 'hybind', ->
 
       it 'should DELETE the association ref link of loaded objects', (done) ->
         http = @http
-        http.andReturn Q _links: self: href: 'http://remotehost/john'
+        response = _links: self: href: 'http://remotehost/john'
+        http.andReturn Q response
         john = @john
         john.$load().then ->
           http.reset()
           john.$remove().then (obj) ->
-            expect(obj).toBe john
+            expect(obj).toBe response
             expect(http).toHaveBeenCalledWith jasmine.objectContaining
               method: 'DELETE', url: 'http://localhost/john'
             done()

--- a/index.spec.coffee
+++ b/index.spec.coffee
@@ -240,7 +240,7 @@ describe 'hybind', ->
           done()
 
     describe '$save', ->
-      it 'should issue a PUT request', (done) ->
+      it 'should issue a PUT request and return a promise that resolves with the model object that corresponds to the payload in the response from the server (if there is one)', (done) ->
         http = @http
         john = @john
         john.errors = [
@@ -249,7 +249,7 @@ describe 'hybind', ->
         response = {
           _links: ''
           _embedded:
-            name: john.name
+            name: john.name # remain unchanged
             errors: [] # the validation error is gone
         }
         http.andReturn Q response
@@ -260,7 +260,7 @@ describe 'hybind', ->
             data: JSON.stringify john
           done()
           
-      it 'should issue a PUT request and ignore the response', (done) ->
+      it 'should issue a PUT request and return a promise that resolves with the (unchanged) model object if there is no payload in the response from the server', (done) ->
         http = @http
         john = @john
         john.errors = [

--- a/index.spec.coffee
+++ b/index.spec.coffee
@@ -46,6 +46,18 @@ describe 'hybind', ->
         obj = @api.$bind 'hello you'
         expect(obj.$bind.ref).toBe 'http://localhost/hello%20you'
 
+    describe '$postEnrich', ->
+      it 'should handle collection items after they are bound', ->
+        postEnrichObj = null;
+        addresses = [
+          { _links: self: href: 'http://localhost/london' },
+          { _links: self: href: 'http://localhost/paris' }
+        ]
+        @api.$postEnrich (obj) ->
+          postEnrichObj = obj;
+        @api.$bind addresses, 'addresses'
+        expect(postEnrichObj).toBe(addresses)
+
     describe 'with object', ->
       it 'should create a self link with given link', ->
         @api.$bind 'j', @john

--- a/index.spec.coffee
+++ b/index.spec.coffee
@@ -13,6 +13,10 @@ describe 'hybind', ->
       expect(@api.$bind.self).toBe 'http://localhost'
     it 'should have $bind function', ->
       expect(typeof @api.$bind).toBe 'function'
+    it 'should have $postEnrich function', ->
+      expect(typeof @api.$postEnrich).toBe 'function'
+    it 'should have $postCollMap function', ->
+      expect(typeof @api.$postCollMap).toBe 'function'
 
   describe '$bind', ->
     describe 'without object', ->

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "q": "^1.4.1"
   },
   "devDependencies": {
-    "coffee-script": "^1.10.0",
-    "jasmine-node": "^1.14.5"
+    "coffeescript": "^2.5.1",
+    "jasmine-node": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "q": "^1.4.1"
   },
   "devDependencies": {
-    "coffeescript": "^2.5.1",
-    "jasmine-node": "^3.0.0"
+    "coffee-script": "^1.10.0",
+    "jasmine-node": "^1.14.5"
   }
 }


### PR DESCRIPTION
Return a promise that resolves with the model object that corresponds to the payload in the response from the server (if there is one).

Before, it always returned the model object because it considered the model object first.

**Note**: If you agree the changes, please create a new release and upload the webjar to _org.webjars.npm_ repository.